### PR TITLE
WIP: Add firewalld configuration rules for dtn nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,15 @@ ansible-playbook -i hosts config_ntp.yaml
 
 Note perfSONAR sets up ntp install so this host is not changed.
 
+# DTN Configuration
+
+## Update firewall
+
+The GridFTP requires ports open for access to control channels to initiate transfers
+and data channels to move data between sites.  The control channel is managed
+by globusonline.org.  The rule sets add permissions for globusonline to initiate
+third-party transfers and allow data to flow to any site.
+
+The configuration uses [firewalld zones](https://www.hogarthuk.com/?q=node/9) to
+control source IP restrictions from globusonline.org.  The on-disk firewall is
+updated and then reloaded into the current state.

--- a/dtn-fw.yaml
+++ b/dtn-fw.yaml
@@ -1,0 +1,44 @@
+#
+# Configure firewall to support Globus services
+#
+# https://docs.globus.org/resource-provider-guide/#open-tcp-ports_section
+#
+# Assumes that CentOS7 configures the public zone by default on the host nic
+#
+# Outbound connections are allowed by default so Outbound restrictions for
+# port 2223 and 443 are not implemented
+#
+- hosts: 'dtn'
+  become: yes
+  become_user: root
+  vars_files:
+  - site_vars.yaml
+
+
+  tasks:
+  - name: open inbound https for oAuth
+    firewalld: service=https permanent=true state=enabled
+
+  - name: open inbound port range for GridFTP data channels
+    firewalld: port=50000—51000/tcp permanent=true state=enabled
+
+  - name: create gridftp control channel zone
+    shell: firewall-cmd --permanent --new-zone=gridftp-control
+
+  - name: add GridFTP control channel from globus.org host 1
+    firewalld: zone=gridftp-control source=184.73.189.163 permanent=true
+
+  - name: open inbound GridFTP control channel from globus.org host 2
+    firewalld: zone=gridftp-control source=174.129.226.69 permanent=true
+
+  - name: open inbound GridFTP control channel port
+    firewalld: zone=gridftp-control port=2811/tcp permanent=true state=enabled
+
+  - name: create myproxy zone
+    shell: firewall-cmd --permanent --new-zone=myproxy
+
+  - name: add MyProxy access from globus.org
+    firewalld: zone=myproxy source=174.129.226.69 permanent=true
+
+  - name: open inbound MyProxy port
+    firewalld: zone=myproxy port=7512/tcp permanent=true state=enabled

--- a/dtn-fw.yaml
+++ b/dtn-fw.yaml
@@ -20,7 +20,7 @@
     firewalld: service=https permanent=true state=enabled
 
   - name: open inbound port range for GridFTP data channels
-    firewalld: port=50000—51000/tcp permanent=true state=enabled
+    firewalld: port=50000-51000/tcp permanent=true state=enabled
 
   - name: create gridftp control channel zone
     shell: firewall-cmd --permanent --new-zone=gridftp-control

--- a/dtn-fw.yaml
+++ b/dtn-fw.yaml
@@ -39,3 +39,6 @@
 
   - name: open inbound MyProxy port
     firewalld: zone=globusonline port=7512/tcp permanent=true state=enabled
+
+  - name: reload firewalld to apply permanent configuration
+    shell: firewall-cmd --reload

--- a/dtn-fw.yaml
+++ b/dtn-fw.yaml
@@ -22,23 +22,20 @@
   - name: open inbound port range for GridFTP data channels
     firewalld: port=50000-51000/tcp permanent=true state=enabled
 
-  - name: create gridftp control channel zone
-    shell: firewall-cmd --permanent --new-zone=gridftp-control
+  - name: create globusonline.org zone for GridFTP control channel and MyProxy
+    shell: firewall-cmd --permanent --new-zone=globusonline
+    register: command_result
+    failed_when: "command_result.rc != 0 and command_result.rc != 26"
+    changed_when: "command_result.rc == 0"
 
-  - name: add GridFTP control channel from globus.org host 1
-    firewalld: zone=gridftp-control source=184.73.189.163 permanent=true
+  - name: add GridFTP control channel from globusonline.org host 1
+    firewalld: zone=globusonline source=184.73.189.163 permanent=true state=enabled
 
-  - name: open inbound GridFTP control channel from globus.org host 2
-    firewalld: zone=gridftp-control source=174.129.226.69 permanent=true
+  - name: add GridFTP control channel from globusonline.org host 2
+    firewalld: zone=globusonline source=174.129.226.69 permanent=true state=enabled
 
-  - name: open inbound GridFTP control channel port
-    firewalld: zone=gridftp-control port=2811/tcp permanent=true state=enabled
-
-  - name: create myproxy zone
-    shell: firewall-cmd --permanent --new-zone=myproxy
-
-  - name: add MyProxy access from globus.org
-    firewalld: zone=myproxy source=174.129.226.69 permanent=true
+  - name: open inbound GridFTP control channel ports
+    firewalld: zone=globusonline port=2811/tcp permanent=true state=enabled
 
   - name: open inbound MyProxy port
-    firewalld: zone=myproxy port=7512/tcp permanent=true state=enabled
+    firewalld: zone=globusonline port=7512/tcp permanent=true state=enabled


### PR DESCRIPTION
This opens the ports for the globus services for
interacting with globus.org

The playbook is hanging on the port range rule for port=50000-51000/tcp.  Eventually just kill with interrupt.  Only the initial https service add is in place at this point.

Playlist currently only changes permanent rules and doesn't reload the firewall.
