### PR TITLE
Add basic playbook to mount ceph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+env
 venv
 site_vars.yaml
 hosts

--- a/ceph_mount.yml
+++ b/ceph_mount.yml
@@ -1,0 +1,95 @@
+---
+ - hosts: dtn
+   become: yes
+   become_user: root
+   gather_facts: yes
+   vars_files:
+     - site_vars.yaml
+   tasks:
+   - name: Ensure prerequsite packages are installed
+     yum:
+       name:
+         - NetworkManager
+         - epel-release
+       state: present 
+
+   - name: Start NetworkManager service
+     ansible.builtin.systemd:
+       name: NetworkManager
+       state: started
+       enabled: yes
+
+   - name: Set up ceph vlan interface
+     community.general.nmcli:
+       conn_name: "{{ ceph_vlan.parent_device }}.{{ ceph_vlan.vlan_id }}"
+       type: vlan
+       vlandev: "{{ ceph_vlan.parent_device }}"
+       vlanid: "{{ ceph_vlan.vlan_id }}"
+       ip4: "{{ ceph_vlan.ipv4_addr }}"
+       state: present
+
+   - name: Update ca-certificates
+     yum:
+       name: ca-certificates
+       state: latest
+
+   - name: Get ceph gpg key
+     rpm_key:
+       state: present
+       key: https://download.ceph.com/keys/release.asc
+       #validate_certs: no # but why?
+
+   - name: Add ceph base repository
+     yum_repository:
+       name: Ceph
+       file: ceph
+       description: Ceph $basearch
+       baseurl: https://download.ceph.com/rpm-octopus/el7/$basearch
+       gpgkey: https://download.ceph.com/keys/release.asc
+       gpgcheck: yes
+
+   - name: Add ceph noarch repository
+     yum_repository:
+       name: Ceph-noarch
+       file: ceph
+       description: Ceph noarch
+       baseurl: https://download.ceph.com/rpm-octopus/el7/noarch
+       gpgkey: https://download.ceph.com/keys/release.asc
+       gpgcheck: yes
+
+   - name: Install ceph packages
+     yum:
+       name:
+         - ceph-common
+         - attr
+       state: present
+       update_cache: yes
+
+   - name: Write ceph.conf
+     ansible.builtin.template:
+       src: ceph.conf.j2
+       dest: /etc/ceph/ceph.conf
+       owner: root
+       group: root
+       mode: u=rw,g=r,o=r
+
+   - name: "Write ceph.client.{{ ceph_client_name }}.keyring"
+     ansible.builtin.template:
+       src: ceph.keyring.j2
+       dest: "/etc/ceph/ceph.client.{{ ceph_client_name }}.keyring"
+       owner: root
+       group: root
+       mode: u=rw,g=r,o=r
+
+   - name: "Ensure directory mountpoint {{ ceph_mountpoint }} exists"
+     ansible.builtin.file:
+       path: "{{ ceph_mountpoint }}"
+       state: directory
+
+   - name: Mount ceph
+     ansible.posix.mount:
+       path: "{{ ceph_mountpoint }}"
+       src: ":/"
+       fstype: ceph
+       opts: "_netdev,name={{ ceph_client_name }}"
+       state: mounted

--- a/example-site_vars.yaml
+++ b/example-site_vars.yaml
@@ -6,3 +6,21 @@
 # 
 timezone: 'US/Central'
 globus_endpoint_name: "{{ globus_username }}#{{ ansible_hostname }}"
+
+##
+# ceph variables
+##
+
+# ceph.conf item(s)
+fsid: "123e4567-e89b-12d3-a456-426614174000"
+mon_host_str: "[v2:10.1.2.1:3300/0,v1:10.1.2.1:6789/0] [v2:10.1.2.2:3300/0,v1:10.1.2.2:6789/0] [v2:10.1.2.3:3300/0,v1:10.1.2.3:6789/0]"
+# cephx client name/key
+ceph_client_name: "client-name"
+ceph_client_key: "dGhpcyBpcyB0b3RhbGx5IGEgdmVyeSByZWFsIHNlY3JldAo="
+# cephfs mount point
+ceph_mountpoint: "/ceph-mount-point"
+# ceph vlan configuration
+ceph_vlan:
+  parent_device: eth0
+  vlan_id: 1111
+  ipv4_addr: "10.1.3.123/22"

--- a/templates/ceph.conf.j2
+++ b/templates/ceph.conf.j2
@@ -1,0 +1,3 @@
+[global]
+        fsid = {{ fsid }}
+        mon_host = {{ mon_host_str }}

--- a/templates/ceph.keyring.j2
+++ b/templates/ceph.keyring.j2
@@ -1,0 +1,2 @@
+[client.{{ ceph_client_name }}]
+        key = {{ ceph_client_key }}


### PR DESCRIPTION
Add a basic playbook (`ceph_mount.yml`) to deploy required software and configurations in order to mount ceph on a host.

This makes a number of concessions in order to reduce complexity (and to keep initial PR small), specifically:

* This assumes that cephfs is mounted via vlan access. In the future, it would be good to make a variable (or the absence of a variable) to ignore setting up the vlan entirely (or to set up another address on an existing interface or etc).
* One of the default ways to manipulate networks in an idempotent way in ansible is via the `community.general.nmcli` module – which has a `NetworkManager` prerequisite. While I think that, long-term, NetworkManager will become the de facto way of interaction with networks on RHEL (and derivatives), this makes the assumption that NetworkManager *isn't* installed.
* The keyring template file takes a dumb string parameter for the `mon_host` parameter; in the future, it might be best to have a more complex layout, but that's perhaps a pipe dream.