### PR TITLE
globus 5 basic setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 venv
+env
 site_vars.yaml
 hosts
 config/sudoers/zz-ansible-admin

--- a/README.md
+++ b/README.md
@@ -86,4 +86,31 @@ if required dependency is not met.
 
 # Globus v5 endpoints
 
-In order to use the `globus_5_playbook.yml` playbook, you must register an endpoint at [the globus development portal](https://auth.globus.org/v2/web/developers) and use the associated client id/secret variables in group vars
+In order to use the `globus_5_playbook.yml` playbook, you must register an endpoint at [the globus development portal](https://auth.globus.org/v2/web/developers) and use the associated client id/secret variables in group vars.
+
+## Setting up box connector
+
+Once globus v5 is set up and deployed, you can create a collection that supports box with the following commands:
+
+```bash
+globus-connect-server storage-gateway create box ${GATEWAY_NAME} --high-assurance --domain ${DOMAIN_SUFFIX} --authentication-timeout-mins ${TIMEOUT_IN_MINUTES} --box-settings file:${BOX_JSON_FILE}
+```
+
+With the following variables:
+
+* `$GATEWAY_NAME` - a short name to refer to the gateway by; in my testing, I had named it `ha-box-connector`
+* `${DOMAIN_SUFFIX}` - the domain you want to scope the gateway to; this is only a hard requirement with `--high-assurance`
+* `${TIMEOUT_IN_MINUTES}` - the web UI timeout for inactivity, in minutes; this is only a hard requirement with `--high-assurance`
+* `${BOX_JSON_FILE}` - a path to the box json file. You should be able to get a json file out of your box apps (found [here](https://uab.app.box.com/developers/console))
+
+This command will give a UUID to use with the next step.
+
+```bash
+globus-connect-server collection create ${GATEWAY_UUID} ${BOX_PATH} "${COLLECTION_NAME}"
+```
+
+With the following variables
+
+* `${GATEWAY_UUID}` - the UUID from the previous command.
+* `${BOX_PATH}` - The path to "scope" within box. For example, if you set the path as `/box`, it will only allow users to transfer files out of their box account if they had a folder in their root *named* `box`. If you set this as `/`, it will allow access to the user's entire box folder
+* `${COLLECTION_NAME}` - A friendly human-readable string; this will be searchable through the globus web interface.

--- a/README.md
+++ b/README.md
@@ -83,3 +83,7 @@ This required a pexpect package installed on the DTNs.
 The pexpect version 2.3 included with CentOS7 is less than the reported
 compatible 3.3+ required by the expect module.  This step can be run by hand if
 if required dependency is not met.
+
+# Globus v5 endpoints
+
+In order to use the `globus_5_playbook.yml` playbook, you must register an endpoint at [the globus development portal](https://auth.globus.org/v2/web/developers) and use the associated client id/secret variables in group vars

--- a/globus_5_playbook.yml
+++ b/globus_5_playbook.yml
@@ -33,31 +33,32 @@
    gather_facts: yes
    tasks:
 
-   - template:
-       src: conf_files/globus-connect-server.conf
-       dest: /etc/globus-connect-server.conf
-       backup: yes
-
-   - ansible.builtin.shell: |
+   - name: "Perform globus endpoint setup"
+     ansible.builtin.shell: |
+       log_file /tmp/globus-connect-server-endpoint-setup.log
        set timeout 300
-       spawn globus-connect-server endpoint setup "ansible-deploy" --organization "UAB" --client-id "6e2c5731-8416-458c-9ad7-e100ce1c2fc4" --owner "kingtc@uab.edu" --contact-email "kingtc@uab.edu" --agree-to-letsencrypt-tos
+       spawn globus-connect-server endpoint setup "{{ globus_endpoint_name }}" --organization "{{ globus_organization }}" --client-id "{{ globus_client_id }}" --owner "{{ globus_endpoint_owner }}" --contact-email "{{ globus_contact_email }}" --agree-to-letsencrypt-tos --deployment-key /etc/globus/deployment-key.json
        
-       expect "\nSecret*"
-       send "{{ globus_secret }}\n"
+       expect "Secret*"
+       send "{{ globus_endpoint_secret }}\r"
 
-       expect "\nDo you agree to these Terms of Service*"
-       send "y\n"
-
-       exit 0
+       expect eof
      args:
        executable: /usr/bin/expect
 
-   vars_prompt:
-    - name: globus_secret
-      prompt: "Enter your Globus Endpoint Secret:"
-      private: yes
-    - name: globus_username
-      prompt: "Enter your Globus username:"
+   - name: "Perform globus node setup"
+     ansible.builtin.shell: |
+       log_file /tmp/globus-connect-server-node-setup.log
+       set timeout 300
+       spawn globus-connect-server node setup --client-id "{{ globus_client_id }}" --ip-address {{ globus_endpoint_ipv4 }} --deployment-key /etc/globus/deployment-key.json
+
+       
+       expect "Secret*"
+       send "{{ globus_endpoint_secret }}\r"
+
+       expect eof
+     args:
+       executable: /usr/bin/expect
 
    vars:
      globus_endpoint_name: "{{ globus_username }}#{{ ansible_hostname }}"

--- a/globus_5_playbook.yml
+++ b/globus_5_playbook.yml
@@ -1,0 +1,66 @@
+---
+ - hosts: dtn
+   become: yes
+   become_user: root
+   gather_facts: yes
+   tasks:
+
+   - name: install globus repo
+     yum: name=https://downloads.globus.org/globus-connect-server/stable/installers/repo/rpm/globus-repo-latest.noarch.rpm state=present
+
+   - name: install epel repo
+     yum: name=epel-release state=present
+
+   - name: get globus gpg key
+     rpm_key: state=present key=https://downloads.globus.org/toolkit/gt6/stable/repo/rpm/RPM-GPG-KEY-Globus
+
+   - name: install yum-plugin-priorities
+     yum: name=yum-plugin-priorities state=present
+
+   - name: install globus-connect-server and required ansible packages
+     yum:
+       name: "{{ packages }}"
+       state: present
+       enablerepo: base
+     vars:
+       packages:
+         - globus-connect-server54
+         - expect
+
+ - hosts: dtn
+   become: yes
+   become_user: root
+   gather_facts: yes
+   tasks:
+
+   - template:
+       src: conf_files/globus-connect-server.conf
+       dest: /etc/globus-connect-server.conf
+       backup: yes
+
+   - ansible.builtin.shell: |
+       set timeout 300
+       spawn globus-connect-server endpoint setup "ansible-deploy" --organization "UAB" --client-id "6e2c5731-8416-458c-9ad7-e100ce1c2fc4" --owner "kingtc@uab.edu" --contact-email "kingtc@uab.edu" --agree-to-letsencrypt-tos
+       
+       expect "\nSecret*"
+       send "{{ globus_secret }}\n"
+
+       expect "\nDo you agree to these Terms of Service*"
+       send "y\n"
+
+       exit 0
+     args:
+       executable: /usr/bin/expect
+
+   vars_prompt:
+    - name: globus_secret
+      prompt: "Enter your Globus Endpoint Secret:"
+      private: yes
+    - name: globus_username
+      prompt: "Enter your Globus username:"
+
+   vars:
+     globus_endpoint_name: "{{ globus_username }}#{{ ansible_hostname }}"
+     globus_endpoint_restrict_paths: "RW/home"
+   vars_files:
+     - site_vars.yaml


### PR DESCRIPTION
This adds a basic setup for globus 5.4 and included some basic instructions for setting up a box connector.

Like my ceph PR, this makes a number of concessions in order to meet a requirement of just deploying globus:

* The playbook isn't very thorough and only set to meet basic needs. I found out halfway through this playbook's creation that globus has a set of [playbooks](https://github.com/globus/gcsv5_installer) that provide a more completely deployment. I believe our discussion was to backlog investigating this until sometime later.
* This playbook assumes that the user is familiar with the new `globus-connect-server` cli tools (which appear to be new as of globus 5). There is actually some quite good documentation for the gateway and collection creation subcommands [here](https://docs.globus.org/globus-connect-server/v5/reference/storage-gateway/) and [here](https://docs.globus.org/globus-connect-server/v5/reference/collection/), however, some basic documentation is provided for quickly bootstrapping a box connector endpoint with high assurance